### PR TITLE
fix(Auth.svelte): initialize role w/ null instead of empty array to e…

### DIFF
--- a/src/lib/actions/Auth.svelte
+++ b/src/lib/actions/Auth.svelte
@@ -14,7 +14,7 @@
 	let password_confirm = "";
 	let email = "";
 	let invitation = "";
-	let roles: RoleType[] = [];
+	let roles: RoleType[] | null = null;
 
 	$: {
 		console.log("switched to mode: " + mode);


### PR DESCRIPTION
…xpress that role is not provided by client